### PR TITLE
F #src 2782 teleop collisions

### DIFF
--- a/jog_arm/config/jog_settings.yaml
+++ b/jog_arm/config/jog_settings.yaml
@@ -1,5 +1,6 @@
 gazebo: true # Whether the robot is started in a Gazebo simulation environment
 collision_check: true # Check collisions?
+collision_check_synchronous: false # Check collisions in the jogging thread in order to avoid them.
 command_in_topic:  jog_arm_server/delta_jog_cmds
 joint_command_in_topic: jog_arm_server/joint_delta_jog_cmds
 command_frame:  base_link  # TF frame that incoming cmds are given in

--- a/jog_arm/config/jog_settings.yaml
+++ b/jog_arm/config/jog_settings.yaml
@@ -10,6 +10,7 @@ move_group_name:  arm  # Often 'manipulator' or 'arm'
 singularity_threshold:  45  # Slow down when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 50 # Stop when the condition number hits this
 command_out_topic:  sia5_controller/command
+solution_out_topic: jog_arm_server/solution
 planning_frame:  base_link  # The MoveIt! planning frame. Often 'base_link'
 low_pass_filter_coeff:  2.  # Larger --> trust the filtered data more, trust the measurements less.
 publish_period:  0.008  # 1/Nominal publish rate [seconds]

--- a/jog_arm/include/jog_arm/jog_arm_server.h
+++ b/jog_arm/include/jog_arm/jog_arm_server.h
@@ -92,7 +92,8 @@ struct jog_arm_parameters
       warning_topic, joint_command_in_topic;
   double linear_scale, rotational_scale, joint_scale, singularity_threshold, hard_stop_singularity_threshold,
       low_pass_filter_coeff, publish_period, publish_delay, incoming_command_timeout, joint_limit_margin;
-  bool gazebo, collision_check, publish_joint_positions, publish_joint_velocities, calculate_with_zero_deltas;
+  bool gazebo, collision_check, collision_check_synchronous, publish_joint_positions, publish_joint_velocities,
+      calculate_with_zero_deltas;
 };
 
 /**
@@ -235,6 +236,8 @@ protected:
 
   bool checkIfImminentCollision(jog_arm_shared& shared_variables);
 
+  bool checkIfSolutionCollides(sensor_msgs::JointState joint_state);
+
   trajectory_msgs::JointTrajectory composeOutgoingMessage(sensor_msgs::JointState& joint_state,
                                                           const ros::Time& stamp) const;
 
@@ -247,6 +250,14 @@ protected:
   const robot_state::JointModelGroup* joint_model_group_;
 
   robot_state::RobotStatePtr kinematic_state_;
+
+  planning_scene::PlanningScenePtr planning_scene_;
+
+  collision_detection::CollisionRequest collision_request_;
+
+  collision_detection::CollisionResult collision_result_;
+
+  moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
 
   sensor_msgs::JointState jt_state_, orig_jts_, last_jts_;
   trajectory_msgs::JointTrajectory new_traj_;

--- a/jog_arm/include/jog_arm/jog_arm_server.h
+++ b/jog_arm/include/jog_arm/jog_arm_server.h
@@ -48,6 +48,8 @@
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit_msgs/DisplayRobotState.h>
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 #include <sensor_msgs/JointState.h>
 #include <sensor_msgs/Joy.h>
@@ -89,7 +91,7 @@ struct jog_arm_shared
 struct jog_arm_parameters
 {
   std::string move_group_name, joint_topic, command_in_topic, command_frame, command_out_topic, planning_frame,
-      warning_topic, joint_command_in_topic;
+      warning_topic, joint_command_in_topic, solution_out_topic;
   double linear_scale, rotational_scale, joint_scale, singularity_threshold, hard_stop_singularity_threshold,
       low_pass_filter_coeff, publish_period, publish_delay, incoming_command_timeout, joint_limit_margin;
   bool gazebo, collision_check, collision_check_synchronous, publish_joint_positions, publish_joint_velocities,
@@ -236,7 +238,7 @@ protected:
 
   bool checkIfImminentCollision(jog_arm_shared& shared_variables);
 
-  bool checkIfSolutionCollides(sensor_msgs::JointState joint_state);
+  bool checkIfSolutionCollides(sensor_msgs::JointState joint_state, jog_arm_shared& shared_variables);
 
   trajectory_msgs::JointTrajectory composeOutgoingMessage(sensor_msgs::JointState& joint_state,
                                                           const ros::Time& stamp) const;
@@ -267,7 +269,7 @@ protected:
   std::vector<jog_arm::LowPassFilter> velocity_filters_;
   std::vector<jog_arm::LowPassFilter> position_filters_;
 
-  ros::Publisher warning_pub_;
+  ros::Publisher warning_pub_, solution_pub_;
 
   jog_arm_parameters parameters_;
 };

--- a/jog_arm/src/jog_arm/jog_arm_server.cpp
+++ b/jog_arm/src/jog_arm/jog_arm_server.cpp
@@ -240,6 +240,9 @@ JogCalcs::JogCalcs(const jog_arm_parameters& parameters, jog_arm_shared& shared_
   // Publish collision status
   warning_pub_ = nh_.advertise<std_msgs::Bool>(parameters_.warning_topic, 1);
 
+  // Publish latest solution (for latency visualisation, collision debugging etc.)
+  solution_pub_ = nh_.advertise<moveit_msgs::DisplayRobotState>(parameters_.solution_out_topic, 1);
+
   // MoveIt Setup
   // Wait for model_loader_ptr to be non-null.
   while ( ros::ok() && !model_loader_ptr )
@@ -489,7 +492,8 @@ bool JogCalcs::cartesianJogCalcs(const geometry_msgs::TwistStamped& cmd, jog_arm
   if (!checkIfImminentCollision(shared_variables) ||
       !verifyJacobianIsWellConditioned(old_jacobian, delta_theta, jacobian, new_traj_) ||
       !checkIfJointsWithinBounds(new_traj_) ||
-      (parameters_.collision_check && parameters_.collision_check_synchronous && !checkIfSolutionCollides(jt_state_)))
+      (parameters_.collision_check && parameters_.collision_check_synchronous &&
+      !checkIfSolutionCollides(jt_state_, shared_variables)))
   {
     avoidIssue(new_traj_);
     publishWarning(true);
@@ -543,7 +547,8 @@ bool JogCalcs::jointJogCalcs(const jog_msgs::JogJoint& cmd, jog_arm_shared& shar
 
   // apply several checks if new joint state is valid
   if (!checkIfImminentCollision(shared_variables) || !checkIfJointsWithinBounds(new_traj_) ||
-      (parameters_.collision_check && parameters_.collision_check_synchronous && !checkIfSolutionCollides(jt_state_)))
+      (parameters_.collision_check && parameters_.collision_check_synchronous &&
+      !checkIfSolutionCollides(jt_state_, shared_variables)))
   {
     avoidIssue(new_traj_);
     publishWarning(true);
@@ -664,13 +669,27 @@ bool JogCalcs::checkIfImminentCollision(jog_arm_shared& shared_variables)
   return 1;
 }
 
-bool JogCalcs::checkIfSolutionCollides(sensor_msgs::JointState joint_state)
+bool JogCalcs::checkIfSolutionCollides(sensor_msgs::JointState joint_state, jog_arm_shared& shared_variables)
 {
+  // Get current joint state
   robot_state::RobotState& current_state = planning_scene_->getCurrentStateNonConst();
+  pthread_mutex_lock(&shared_variables.joints_mutex);
+  sensor_msgs::JointState current_jts = shared_variables.joints;
+  pthread_mutex_unlock(&shared_variables.joints_mutex);
+  for (std::size_t i = 0; i < current_jts.position.size(); ++i)
+    current_state.setJointPositions(current_jts.name[i], &current_jts.position[i]);
+
+  // Change to solution joint states
   for (std::size_t i=0; i< joint_state.position.size(); i++)
   {
     current_state.setJointPositions(joint_state.name[i], &joint_state.position[i]);
   }
+
+  // Publish solution for visualisation
+  moveit_msgs::DisplayRobotState solution_state_msg;
+  robotStateToRobotStateMsg(current_state, solution_state_msg.state, false);
+  solution_pub_.publish(solution_state_msg);
+  
   // process collision objects in scene
   std::map<std::string, moveit_msgs::CollisionObject> c_objects_map = planning_scene_interface_.getObjects();
   for (auto& kv : c_objects_map)
@@ -1001,6 +1020,7 @@ int JogROSInterface::readParameters(ros::NodeHandle& n)
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/incoming_command_timeout",
                                     ros_parameters_.incoming_command_timeout);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/command_out_topic", ros_parameters_.command_out_topic);
+  error += !rosparam_shortcuts::get("", n, parameter_ns + "/solution_out_topic", ros_parameters_.solution_out_topic);
   error +=
       !rosparam_shortcuts::get("", n, parameter_ns + "/singularity_threshold", ros_parameters_.singularity_threshold);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/hard_stop_singularity_threshold",

--- a/jog_arm/src/jog_arm/jog_arm_server.cpp
+++ b/jog_arm/src/jog_arm/jog_arm_server.cpp
@@ -99,10 +99,10 @@ JogROSInterface::JogROSInterface()
   }
 
   // ROS subscriptions. Share the data with the worker threads
-  ros::Subscriber cmd_sub = n.subscribe(ros_parameters_.command_in_topic, 1, &JogROSInterface::deltaCmdCB, this);
-  ros::Subscriber joints_sub = n.subscribe(ros_parameters_.joint_topic, 1, &JogROSInterface::jointsCB, this);
+  ros::Subscriber cmd_sub = n.subscribe(ros_parameters_.command_in_topic, 1, &JogROSInterface::deltaCmdCB, this, ros::TransportHints().tcpNoDelay());
+  ros::Subscriber joints_sub = n.subscribe(ros_parameters_.joint_topic, 1, &JogROSInterface::jointsCB, this, ros::TransportHints().tcpNoDelay());
   ros::Subscriber joint_jog_cmd_sub =
-      n.subscribe(ros_parameters_.joint_command_in_topic, 1, &JogROSInterface::deltaJointCmdCB, this);
+      n.subscribe(ros_parameters_.joint_command_in_topic, 1, &JogROSInterface::deltaJointCmdCB, this, ros::TransportHints().tcpNoDelay());
   ros::topic::waitForMessage<sensor_msgs::JointState>(ros_parameters_.joint_topic);
   ros::topic::waitForMessage<geometry_msgs::TwistStamped>(ros_parameters_.command_in_topic);
 


### PR DESCRIPTION
This PR merges in F_improve_latency also, as we shouldn't be running off a branch as standard.

The main purpose of this branch is to fix the synchronous collision checking not knowing the pose of the rest of the robot.